### PR TITLE
增加了gui界面金额输入框的货币分隔符

### DIFF
--- a/DFMarketBot.py
+++ b/DFMarketBot.py
@@ -183,8 +183,8 @@ def runApp():
     key_monitor.key_pressed.connect(handle_key_event)
     
     def handle_text_change():
-        ideal = int(mainWindow.textEdit_ideal_price.toPlainText())
-        unaccept = int(mainWindow.textEdit_unacceptable_price.toPlainText())
+        ideal = int(mainWindow.get_plain_number(mainWindow.textEdit_ideal_price))
+        unaccept = int(mainWindow.get_plain_number(mainWindow.textEdit_unacceptable_price))
         loop_gap = int(mainWindow.textEdit_loop_gap.toPlainText())
         is_convertible = mainWindow.is_convertiable.isChecked()
         is_key_mode = mainWindow.is_key_mode.isChecked()

--- a/GUI/AppGUI.py
+++ b/GUI/AppGUI.py
@@ -119,6 +119,10 @@ class Ui_MainWindow(object):
         self.retranslateUi(MainWindow)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
+        # 添加千位分隔监听器
+        self.textEdit_ideal_price.textChanged.connect(lambda: self.format_price_input(self.textEdit_ideal_price))
+        self.textEdit_unacceptable_price.textChanged.connect(lambda: self.format_price_input(self.textEdit_unacceptable_price))
+
     def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
         MainWindow.setWindowTitle(_translate("MainWindow", "DFMarketBot"))
@@ -129,3 +133,30 @@ class Ui_MainWindow(object):
         self.is_key_mode.setText(_translate("MainWindow", "钥匙卡模式"))
         self.label_loop_gap.setText(_translate("MainWindow", "循环间隔"))
         self.is_half_coin_mode.setText(_translate("MainWindow", "使用哈夫币余额计算价格"))
+
+    # 自动格式化输入为带逗号的千位格式
+    def format_price_input(self, textEdit: QtWidgets.QTextEdit):
+        cursor = textEdit.textCursor()
+        pos = cursor.position()
+        old_text = textEdit.toPlainText()
+        raw_text = old_text.replace(',', '')
+        if not raw_text.isdigit():
+            return
+        formatted = "{:,}".format(int(raw_text))
+        if formatted == old_text:
+            return
+        old_commas_before_cursor = old_text[:pos].count(',')
+        new_commas_before_cursor = formatted[:pos].count(',')
+        delta = new_commas_before_cursor - old_commas_before_cursor
+        textEdit.blockSignals(True)
+        textEdit.setPlainText(formatted)
+        textEdit.blockSignals(False)
+        new_pos = pos + delta
+        new_pos = max(0, min(len(formatted), new_pos))  # 限制范围
+        cursor.setPosition(new_pos)
+        textEdit.setTextCursor(cursor)
+
+    # 外部调用读取值时使用，自动去除逗号
+    def get_plain_number(self, textEdit: QtWidgets.QTextEdit) -> int:
+        text = textEdit.toPlainText().replace(",", "")
+        return int(text) if text else 0


### PR DESCRIPTION
大额商品输入金额容易输入错位数，增加了一个gui界面金额输入框的货币分割符保证输入符合预期。
已测试主程序拿取货币数值无误。

<img width="443" height="233" alt="image" src="https://github.com/user-attachments/assets/d80f8adf-5aa6-4fed-b22d-43844e4f63ac" />