### PR TITLE
处理兑换按钮消失导致的识别卡死

### DIFF
--- a/DFMarketBot.py
+++ b/DFMarketBot.py
@@ -131,7 +131,11 @@ class Worker(QThread):
                     if first_loop == True:
                         first_loop = False
                 except Exception as e:
-                    print(f"操作失败: {str(e)}")
+                    if str(e) == '识别失败':  # 识别失败, 建议检查物品是否可兑换
+                        self.msleep(self.loop_gap)
+                        self.buybot.freerefresh(good_postion=self.mouse_position)
+                    else:
+                        print(f"操作失败: {str(e)}")
                 self.msleep(self.loop_gap)
             else:
                 self.msleep(100)

--- a/backend/BuyBot.py
+++ b/backend/BuyBot.py
@@ -31,11 +31,12 @@ class BuyBot:
             text = text[-1][1]
             text = text.replace(',', '')
             text = text.replace('.', '')
+            text = text.replace(' ', '')
         except:
             text = None
         if debug_mode == True:
             print(text)
-        return int(text)
+        return int(text) if text else None
 
     def detect_price(self, is_convertible, debug_mode = False):
         if is_convertible:
@@ -47,6 +48,7 @@ class BuyBot:
 
         if self.lowest_price == None:
             print('识别失败, 建议检查物品是否可兑换')
+            raise Exception('识别失败')
         return int(self.lowest_price)
 
     def detect_balance_half_coin(self, debug_mode = False):


### PR DESCRIPTION
1.关于issues#18的“兑换按钮有时候会消失导致识别卡死”问题。改为识别失败后进入下一次循环，防止卡死
2.修改了identify_number函数原返回强转int导致“识别失败, 建议检查物品是否可兑换”和“哈夫币余额检测识别失败或不稳定，建议关闭余额识别相关功能”的报错信息无法正常显示
3.添加了一个replace，1920X1080画质下识别会多空格