### PR TITLE
修改新的补货机制（原为购买1发现为购买31发）

### DIFF
--- a/DFMarketBot.py
+++ b/DFMarketBot.py
@@ -121,7 +121,7 @@ class Worker(QThread):
                         elif lowest_price > current_ideal:
                             print('高于理想价格', current_ideal, ' 刷新价格')
                             self.buybot.refresh(is_convertible=current_convertible)
-                            buy_number = 1
+                            buy_number = 31 #原始值为 购买子弹价格/1 ，修改为 购买子弹价格/31
                         else:
                             print('低于理想价格', current_ideal, ' 开始购买')
                             self.buybot.buy(is_convertible=current_convertible)

--- a/backend/BuyBot.py
+++ b/backend/BuyBot.py
@@ -14,9 +14,9 @@ class BuyBot:
         self.range_isconvertible_lowest_price = [2179/2560, 1078/1440, 2308/2560, 1102/1440]
         self.range_notconvertible_lowest_price = [2179/2560, 1156/1440, 2308/2560, 1178/1440]
         self.postion_isconvertible_max_shopping_number = [0.9085, 0.7222]
-        self.postion_isconvertible_min_shopping_number = [0.7921, 0.7222]
+        self.postion_isconvertible_min_shopping_number = [0.8095, 0.7222]  #"将Buybot.py中的"self.postion_isconvertible_min_shopping_number"临时改为[0.8095, 0.7222], 该值原本为[0.7921, 0.7222]"
         self.postion_notconvertiable_max_shopping_number = [2329/2560, 1112/1440]
-        self.postion_notconvertiable_min_shopping_number = [2028/2560, 1112/1440]
+        self.postion_notconvertiable_min_shopping_number = [2059/2560, 1112/1440] #"将Buybot.py中的"self.postion_notconvertiable_min_shopping_number"临时改为[2059/2560, 1112/1440], 该值原本为[2028/2560, 1112/1440]"
         self.postion_isconvertible_buy_button = [2189/2560, 0.7979]
         self.postion_notconvertiable_buy_button = [2186/2560, 1225/1440]
         self.postion_balance = [2200/2560, 70/1440]


### PR DESCRIPTION
DFMarketBot.py:
高于理想价格哈弗币判定购买金额/1  修改为31，修改内容在注释中。

BuyBot.py:
同步官方修改为31发设定 修改了”self.postion_isconvertible_min_shopping_number“和”self.postion_notconvertiable_min_shopping_number“ 修改内容在注释中。